### PR TITLE
Assign ActivationKey channels only (bsc#1166516)

### DIFF
--- a/java/code/src/com/suse/manager/reactor/messaging/RegistrationUtils.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/RegistrationUtils.java
@@ -15,12 +15,6 @@
 
 package com.suse.manager.reactor.messaging;
 
-import static java.util.Collections.emptyList;
-import static java.util.Collections.emptySet;
-import static java.util.Optional.ofNullable;
-import static java.util.stream.Collectors.partitioningBy;
-import static java.util.stream.Collectors.toSet;
-
 import com.redhat.rhn.common.messaging.MessageQueue;
 import com.redhat.rhn.common.validator.ValidatorResult;
 import com.redhat.rhn.domain.channel.Channel;
@@ -46,19 +40,16 @@ import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
 import com.redhat.rhn.manager.system.entitling.SystemEntitler;
 import com.redhat.rhn.manager.system.entitling.SystemUnentitler;
 import com.redhat.rhn.taskomatic.TaskomaticApiException;
-
 import com.suse.manager.reactor.utils.RhelUtils;
 import com.suse.manager.reactor.utils.ValueMap;
 import com.suse.manager.virtualization.VirtManagerSalt;
 import com.suse.manager.webui.controllers.StatesAPI;
 import com.suse.manager.webui.services.iface.RedhatProductInfo;
+import com.suse.manager.webui.services.iface.SystemQuery;
 import com.suse.manager.webui.services.impl.SaltService;
 import com.suse.manager.webui.services.pillar.MinionPillarManager;
-import com.suse.manager.webui.services.iface.SystemQuery;
 import com.suse.salt.netapi.calls.modules.Zypper;
 import com.suse.utils.Opt;
-import org.apache.log4j.Logger;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -68,6 +59,13 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
+import org.apache.log4j.Logger;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptySet;
+import static java.util.Optional.ofNullable;
+import static java.util.stream.Collectors.partitioningBy;
+import static java.util.stream.Collectors.toSet;
 
 /**
  * Common registration logic that can be used from multiple places

--- a/java/code/webapp/WEB-INF/pages/systems/sdc/overview.jsp
+++ b/java/code/webapp/WEB-INF/pages/systems/sdc/overview.jsp
@@ -217,17 +217,20 @@
         </div>
         <div class="panel-body">
           <c:if test="${system.baseChannel != null}">
+            <h4>Base Channel</h4>
             <ul class="channel-list">
-            <li>
-              <a href="/rhn/channels/ChannelDetail.do?cid=${baseChannel['id']}"><c:out value="${baseChannel['name']}" /></a>
-            </li>
+              <li>
+                <a href="/rhn/channels/ChannelDetail.do?cid=${baseChannel['id']}"><c:out value="${baseChannel['name']}" /></a>
+              </li>
+            </ul>
 
-            <c:forEach items="${childChannels}" var="childChannel">
-            <li class="child-channel">
-              <a href="/rhn/channels/ChannelDetail.do?cid=${childChannel['id']}"><c:out value="${childChannel['name']}" /></a>
-            </li>
-            </c:forEach>
-
+            <h4>Child Channels</h4>
+            <ul class="channel-list">
+              <c:forEach items="${childChannels}" var="childChannel">
+              <li class="child-channel">
+                <a href="/rhn/channels/ChannelDetail.do?cid=${childChannel['id']}"><c:out value="${childChannel['name']}" /></a>
+              </li>
+              </c:forEach>
             </ul>
           </c:if>
         </div>

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Assign Activation Key channels only (bsc#1166516)
 - Pass image profile custom info values as Docker buildargs during image build
 - Fix activation keys request error in image import page (bsc#1170046)
 - Fix custom info values input in image profile edit form (bsc#1169773)


### PR DESCRIPTION
## What does this PR change?

Fix https://bugzilla.suse.com/show_bug.cgi?id=1166516

If an Activation Key is present, with or without a `base channel` defined, on bootstrapping servers, if the Activation Key is used, only the base channel and the selected channels should be assigned, and nothing more.

At the moment the code does not care about the selection, and more important about the not-selected channels. What it does now is to assign:
1- all *mandatory* channels
2- all *recommended* channels
3- all other channels depending on the selection of the AK set. 
Points 1 and 3 are correct, but the point 2 it is not. `recommended` channels are optionals, and if the user prepared an AK without them, we should respect that decision.

@hustodemon @mcalmer (this PR is against another branch of mine, so I invited you to be a collaborator here because I can't add you as a reviewer for the moment, just do not care about it too much). What I need here is your thinking about this change: I need to understand if this change could have drawbacks and/or why it was implemented differently in the first place. My opinion is that if there is no AK during bootstrap, we can guess/preselect/autoselect/do some magic to make users happy, but if there is an AK we should not do anything else than being lead by that selection *only*. Am I missing something?

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed:

- [x] **DONE**

## Test coverage
- No tests: **add explanation**
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes # https://bugzilla.suse.com/show_bug.cgi?id=1166516

Relevant branches (GitHub automatic links expected below):
 - Manager-3.0
 - Manager-3.1
 - Manager-3.2
 - Manager

- [ ] **DONE**
